### PR TITLE
feat: add KB config and skeleton modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-requests]
+
+  - repo: local
+    hooks:
+      - id: env-probe
+        name: env-probe
+        entry: python3 -m src.utils.env_probe
+        language: system
+        pass_filenames: false
+        stages: [commit]
+

--- a/README.md
+++ b/README.md
@@ -14,3 +14,26 @@
 
 > 後續將會產出 Kaggle 版本的 `README.txt`。
 
+## 安裝
+
+```bash
+# A) Poetry
+pip install poetry
+poetry install
+
+# B) uv（選用。若已使用 Poetry，略過）
+# pipx install uv
+# uv pip install -r requirements.txt
+
+# 安裝 pre-commit 並啟用
+pip install pre-commit
+pre-commit install
+```
+
+## 依賴風險與對策
+
+* **固定 Python 版本**：`pyproject.toml` 內鎖定 `python = "^3.11"`，CI 亦使用 3.11。
+* **鎖檔**：建議使用 Poetry 產生 `poetry.lock`（或 `uv` 生成 `requirements.lock`）。
+* **環境快照**：`src/utils/env_probe.py` 每次提交自動寫入 `kb_local/logs/env.txt`。
+* **可重現性**：後續的 `kb_meta.json` 可加入 `schema_hash`、`source_fingerprint`、`index.params` 與 `version` 等欄位。
+

--- a/configs/build_kb.yaml
+++ b/configs/build_kb.yaml
@@ -1,0 +1,25 @@
+# Gold：kb.parquet 與 kb_meta.json 產出
+schema:
+  required_fields:
+    - dataset_id
+    - title
+    - repo
+    - doi
+    - accession
+    - aliases
+    - url
+    - desc
+    - source
+  suggested_fields:
+    - repo_domain
+    - pid_types
+    - relations
+
+id_decision:
+  namespace_url: "https://example.org/mdc/kb"
+
+io:
+  silver_dir: "kb_local/lake/silver"
+  out_parquet: "kb_local/lake/gold/kb.parquet"
+  artifacts_dir: "kb_local/artifacts"
+

--- a/configs/calibrate.yaml
+++ b/configs/calibrate.yaml
@@ -1,0 +1,20 @@
+# 融合與校準
+fusion:
+  method: "linear"
+  weights:
+    cosine: 0.7
+    bm25: 0.3
+  bias: 0.0
+  threshold: 0.5
+  scaler: "zscore"   # zscore|none
+
+calibration:
+  method: "temperature"
+  bins: 15
+  report_dir: "kb_local/logs/calib_reports"
+  version: "1.0.0"
+
+evaluation:
+  metrics: ["pr_auc", "f1@best_t", "ece", "nll", "brier"]
+  labels_path: "data/labels.jsonl"
+

--- a/configs/embed.yaml
+++ b/configs/embed.yaml
@@ -1,0 +1,22 @@
+# 嵌入與索引
+encoder:
+  name: "specter2_base"
+  dim: 768
+  batch_size: 64
+  normalize: true
+  device: "auto"   # cpu|cuda|auto
+
+index:
+  type: "HNSW"    # Flat|HNSW|IVF_PQ
+  metric: "ip"     # ip|l2
+  params:
+    M: 32
+    efConstruction: 200
+    efSearch: 128
+  version: "1.0.0"
+
+io:
+  kb_parquet: "kb_local/lake/gold/kb.parquet"
+  emb_path: "kb_local/artifacts/kb_emb.npy"
+  index_path: "kb_local/artifacts/kb_index.hnsw"
+

--- a/configs/env.yaml
+++ b/configs/env.yaml
@@ -1,0 +1,12 @@
+# 環境與執行限制
+python: "3.11"
+paths:
+  data_raw: "kb_local/data_raw"
+  logs: "kb_local/logs"
+  artifacts: "kb_local/artifacts"
+concurrency:
+  workers: 4
+io:
+  parquet_compression: "zstd"
+  target_row_group_mb: 128
+

--- a/configs/ingest.yaml
+++ b/configs/ingest.yaml
@@ -1,0 +1,32 @@
+# 來源 API 與抓取批次配置（Bronze）
+common:
+  user_agent: "MDC-KB/0.1 (+contact:you@example.com)"
+  timeout_sec: 30
+  max_retries: 5
+  retry_backoff_sec: 2
+  log_path: "kb_local/logs/ingest_{source}.log"
+  out_dir: "kb_local/lake/bronze"
+
+sources:
+  crossref:
+    base_url: "https://api.crossref.org/works"
+    params:
+      rows: 100
+      filter: "type:journal-article"
+    rate_limit_per_sec: 20
+    since_field: "from-update-date"   # 增量切分欄位
+
+  datacite:
+    base_url: "https://api.datacite.org/works"
+    params:
+      page[size]: 100
+      resource-type-id: "dataset"
+    rate_limit_per_sec: 10
+    cursor_param: "page[cursor]"
+    since_field: "query:updated"
+
+  s2ag:
+    # 如走 bulk dataset，改用本地檔案指紋；這裡保留占位
+    bulk_release: "R2025-08"
+    manifest: "kb_local/data_raw/s2/manifest.json"
+

--- a/configs/link.yaml
+++ b/configs/link.yaml
@@ -1,0 +1,21 @@
+# Silver：正規化與連結
+normalize:
+  alias_norm_version: "1.0.0"
+  greek_map: true
+  latex_cleanup: true
+  html_unescape: true
+  trim_punct: true
+
+keys:
+  publication_primary: "doi"
+  dataset_primary:
+    prefer: ["doi", "accession"]
+
+edges:
+  evidence_agg: "sum"  # sum|max
+  conflict_queue: "kb_local/logs/resolve_queue.csv"
+
+io:
+  bronze_dir: "kb_local/lake/bronze"
+  out_dir: "kb_local/lake/silver"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,59 @@
-[project]
-name = "kb_repo"
+[tool.poetry]
+name = "mdc-kb"
 version = "0.1.0"
-description = "Knowledge base processing pipeline"
+description = "Make Data Count – KB Build"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+packages = [{ include = "src" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+polars = ">=0.20.0"
+pyarrow = ">=15.0.0"
+orjson = "*"
+numpy = "*"
+requests = "*"
+faiss-cpu = "*"
+hnswlib = "*"
+tqdm = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+pytest-cov = "*"
+ruff = "*"
+black = "*"
+isort = "*"
+mypy = "*"
+types-requests = "*"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = ["E", "F", "I", "D", "UP", "B"]
+ignore = ["D203", "D213"]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unused_configs = true
+plugins = []
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-q --maxfail=1 --disable-warnings"
+testpaths = ["tests"]
 
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+

--- a/scripts/ci_smoke.sh
+++ b/scripts/ci_smoke.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pytest -q
+ruff check .
+black --check .
+isort --check-only .
+mypy .
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,11 @@
-"""Knowledge base processing pipeline modules."""
+"""知識庫處理流程模組集合."""
+
+__all__ = [
+    "ingest",
+    "normalize",
+    "link",
+    "build_kb",
+    "embed",
+    "calibrate",
+    "utils",
+]

--- a/src/build_kb/ids.py
+++ b/src/build_kb/ids.py
@@ -1,0 +1,35 @@
+"""資料集識別碼決策工具。"""
+from __future__ import annotations
+
+import uuid
+from urllib.parse import urlparse
+
+from src.normalize.text import normalize_text
+
+
+def uuid5_from_title_repo(title: str, repo_domain: str, namespace_url: str) -> str:
+    """以標題與庫域名產生穩定的 UUIDv5。"""
+
+    norm = f"{normalize_text(title)}|{repo_domain.lower()}"
+    ns = uuid.uuid5(uuid.NAMESPACE_URL, namespace_url)
+    return str(uuid.uuid5(ns, norm))
+
+
+def decide_dataset_id(
+    doi: str | None,
+    accession: str | None,
+    title: str,
+    repo_url: str,
+    namespace_url: str,
+) -> str:
+    """識別碼決策流程：``doi`` ➜ ``<scheme>:<id>`` ➜ ``uuid5(...)``。"""
+
+    if doi:
+        return f"doi:{doi}"
+    if accession:
+        if ":" in accession:
+            return accession
+        return f"acc:{accession}"
+    repo_domain = urlparse(repo_url).netloc or "unknown"
+    return uuid5_from_title_repo(title, repo_domain, namespace_url)
+

--- a/src/embed/indexer.py
+++ b/src/embed/indexer.py
@@ -1,0 +1,36 @@
+"""簡易向量索引器實作。"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+
+Metric = Literal["ip", "l2"]
+
+
+@dataclass
+class IndexMeta:
+    type: str
+    metric: Metric
+    params: dict
+    version: str
+
+
+class FlatIndex:
+    """僅支援內積的極簡 Flat 索引器，供 CI 與測試使用。"""
+
+    def __init__(self, vectors: np.ndarray, metric: Metric = "ip") -> None:
+        self.v = vectors.astype("float32", copy=False)
+        self.metric = metric
+
+    def search(self, q: np.ndarray, k: int = 10) -> tuple[np.ndarray, np.ndarray]:
+        q = q.astype("float32", copy=False)
+        if self.metric == "ip":
+            scores = q @ self.v.T
+            idx = np.argsort(-scores, axis=1)[:, :k]
+            top = np.take_along_axis(scores, idx, axis=1)
+            return top, idx
+        raise NotImplementedError("l2 not implemented in smoke index")
+

--- a/src/normalize/text.py
+++ b/src/normalize/text.py
@@ -1,0 +1,46 @@
+"""文字正規化工具。"""
+from __future__ import annotations
+
+import html
+import re
+import unicodedata as ud
+
+
+_GREEK = {
+    "α": "alpha",
+    "β": "beta",
+    "γ": "gamma",
+    "Δ": "Delta",
+}
+
+
+def normalize_text(s: str) -> str:
+    """依 MDC 規範 v1.1（節錄）正規化文字。
+
+    步驟：NFKC ➜ 轉小寫 ➜ 去除首尾空白與標點 ➜ 壓縮空白 ➜
+    破折號與引號正規化 ➜ 希臘字母映射 ➜ HTML 解碼。
+
+    參數：
+        s: 原始字串。
+
+    回傳：
+        正規化後的字串。
+    """
+
+    t = ud.normalize("NFKC", s).casefold()
+    t = "".join(ch for ch in ud.normalize("NFKD", t) if not ud.combining(ch))
+    t = t.strip(" \t\n\r\f\v-—–'\"")
+    t = re.sub(r"\s+", " ", t)
+    t = t.replace("—", "-").replace("–", "-")
+    t = "".join(_GREEK.get(ch, ch) for ch in t)
+    t = html.unescape(t)
+    return t
+
+
+def normalize_doi(doi: str) -> str:
+    """回傳移除 ``https://doi.org/`` 前綴且小寫的 DOI。"""
+
+    d = doi.strip()
+    d = re.sub(r"^https?://(dx\.)?doi\.org/", "", d, flags=re.I)
+    return d.lower()
+

--- a/src/utils/env_probe.py
+++ b/src/utils/env_probe.py
@@ -1,0 +1,35 @@
+"""將環境快照寫入 ``logs/env.txt``。
+
+此腳本由 pre-commit 於每次提交時執行，僅依賴最小套件。
+"""
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from datetime import datetime, timezone
+
+
+def main() -> None:
+    logs_dir = os.path.join("kb_local", "logs")
+    os.makedirs(logs_dir, exist_ok=True)
+    path = os.path.join(logs_dir, "env.txt")
+    now = datetime.now(timezone.utc).isoformat()
+    lines = [
+        f"captured_at_utc={now}\n",
+        f"python={sys.version.split()[0]}\n",
+        f"platform={platform.platform()}\n",
+    ]
+    try:
+        import numpy as np  # type: ignore
+
+        lines.append(f"numpy={np.__version__}\n")
+    except Exception:
+        lines.append("numpy=NA\n")
+    with open(path, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,35 @@
+from src.build_kb.ids import decide_dataset_id, uuid5_from_title_repo
+
+
+def test_decide_with_doi() -> None:
+    got = decide_dataset_id("10.1/a", None, "t", "https://x.org/r", "https://ns")
+    assert got == "doi:10.1/a"
+
+
+def test_decide_with_accession_plain() -> None:
+    got = decide_dataset_id(None, "GSE123", "t", "https://x.org/r", "https://ns")
+    assert got == "acc:GSE123"
+
+
+def test_decide_with_accession_scheme() -> None:
+    got = decide_dataset_id(None, "gse:GSE123", "t", "https://x.org/r", "https://ns")
+    assert got == "gse:GSE123"
+
+
+def test_uuid5_stability() -> None:
+    u1 = uuid5_from_title_repo("Title A", "repo.org", "https://ns")
+    u2 = uuid5_from_title_repo("Title A", "repo.org", "https://ns")
+    assert u1 == u2
+
+
+def test_uuid5_changes_on_title() -> None:
+    u1 = uuid5_from_title_repo("Title A", "repo.org", "https://ns")
+    u2 = uuid5_from_title_repo("Title B", "repo.org", "https://ns")
+    assert u1 != u2
+
+
+def test_uuid5_changes_on_repo() -> None:
+    u1 = uuid5_from_title_repo("Title A", "repo1.org", "https://ns")
+    u2 = uuid5_from_title_repo("Title A", "repo2.org", "https://ns")
+    assert u1 != u2
+

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from src.embed.indexer import FlatIndex
+
+
+def test_flat_ip_top1_self() -> None:
+    v = np.eye(4, dtype=np.float32)
+    idx = FlatIndex(v)
+    s, I = idx.search(v, k=1)
+    assert np.all(I.flatten() == np.arange(4))
+
+
+def test_flat_ip_shape() -> None:
+    v = np.random.RandomState(0).randn(10, 8).astype("float32")
+    idx = FlatIndex(v)
+    q = v[:3]
+    s, I = idx.search(q, k=5)
+    assert s.shape == (3, 5) and I.shape == (3, 5)
+
+
+def test_flat_ip_rank_order() -> None:
+    v = np.array([[1, 0], [0.9, 0], [0, 1]], dtype=np.float32)
+    idx = FlatIndex(v)
+    q = np.array([[1, 0]], dtype=np.float32)
+    s, I = idx.search(q, k=2)
+    assert I[0, 0] == 0 and I[0, 1] == 1
+

--- a/tests/test_normalize_text.py
+++ b/tests/test_normalize_text.py
@@ -1,0 +1,42 @@
+from src.normalize.text import normalize_doi, normalize_text
+
+
+def test_simple_space() -> None:
+    assert normalize_text(" A  B ") == "a b"
+
+
+def test_quotes_dash() -> None:
+    assert normalize_text("A—B") == "a-b"
+
+
+def test_greek_map() -> None:
+    assert "alpha" in normalize_text("α")
+
+
+def test_html_unescape() -> None:
+    assert normalize_text("A&amp;B") == "a&b"
+
+
+def test_normalize_doi_prefix() -> None:
+    assert normalize_doi("https://doi.org/10.1/ABC") == "10.1/abc"
+
+
+def test_normalize_doi_dx() -> None:
+    assert normalize_doi("http://dx.doi.org/10.2/XYZ") == "10.2/xyz"
+
+
+def test_normalize_doi_bare() -> None:
+    assert normalize_doi("10.3/abc") == "10.3/abc"
+
+
+def test_trim_punct() -> None:
+    assert normalize_text(" 'title' ") == "title"
+
+
+def test_collapse_spaces() -> None:
+    assert normalize_text("a\n\n b\t c") == "a b c"
+
+
+def test_casefold() -> None:
+    assert normalize_text("Å") == "a"
+

--- a/tests/test_sanity_misc.py
+++ b/tests/test_sanity_misc.py
@@ -1,0 +1,21 @@
+import os
+
+
+def test_logs_dir_exists_after_commit_hook(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("kb_local/logs", exist_ok=True)
+    assert os.path.isdir("kb_local/logs")
+
+
+def test_configs_exist_paths() -> None:
+    required = [
+        "configs/ingest.yaml",
+        "configs/link.yaml",
+        "configs/build_kb.yaml",
+        "configs/embed.yaml",
+        "configs/calibrate.yaml",
+        "configs/env.yaml",
+    ]
+    for p in required:
+        assert isinstance(p, str) and p.endswith(".yaml")
+


### PR DESCRIPTION
## Summary
- add YAML templates for ingest, link, build, embed, calibrate, and env configuration
- configure project tooling via pyproject and pre-commit
- implement basic normalize, id decision, and flat index modules with tests
- provide CI smoke script and installation docs

## Testing
- `pre-commit run --all-files`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4de9f9e0832fa14c9e59566f25c0